### PR TITLE
use selected version

### DIFF
--- a/src/helpers/avm.ts
+++ b/src/helpers/avm.ts
@@ -24,6 +24,7 @@ export const installAvm = async () => vscode.window.withProgress({
   }
 });
 
+export const avmUse = async (version: string) => spawnChan('avm', ['use', version], 'avm list', '', true);
 
 export const installAnchorUsingAvm = async () => {
   try {
@@ -49,6 +50,7 @@ export const installAnchorUsingAvm = async () => {
       cancellable: false
     }, async (progress, token) => {
       const isInstalled = await spawnChan('avm', ['install', version], `avm install ${version}`);
+      await avmUse(version);
       return Promise.resolve(isInstalled);
     });
   } catch (err) {


### PR DESCRIPTION
While installing anchor version through avm, extension forgot to start using the version directly.